### PR TITLE
issue #38 - implicit p:inline

### DIFF
--- a/langspec/schemas/xproc.rnc
+++ b/langspec/schemas/xproc.rnc
@@ -82,6 +82,8 @@ version.attr = attribute version { text }
 
 common.attributes = xmlid.attr?, xmlbase.attr?, extension.attr*
 
+inline.attributes = exclude-inline-prefixes.attr?, attribute expand-text { xsd:boolean }?
+
 decl.attributes = psvi-required.attr?,
    xpath-version.attr?,
    exclude-inline-prefixes.attr?,
@@ -152,8 +154,9 @@ InputDeclaration =
       attribute media-types { MediaTypes }?,
       select.attr?,
       common.attributes,
+      inline.attributes,
       use-when.attr?,
-      ((\Empty|(Document|Inline)+)? & (Documentation|PipeInfo)*)
+      ((\Empty|Any|(Document|Inline)+)? & (Documentation|PipeInfo)*)
    }
 
 [
@@ -164,8 +167,9 @@ InputConnection =
       port.attr,
       select.attr?,
       common.attributes,
+      inline.attributes,
       use-when.attr?,
-      ((\Empty|(Pipe|Document|Inline)+)? & (Documentation|PipeInfo)*)
+      ((\Empty|Any|(Pipe|Document|Inline)+)? & (Documentation|PipeInfo)*)
    }
 
 [
@@ -197,8 +201,9 @@ OutputConnection =
       sequence.attr?,
       primary.attr?,
       common.attributes,
+      inline.attributes,
       use-when.attr?,
-      ((\Empty|(Pipe|Document|Inline)+)? & (Documentation|PipeInfo)*)
+      ((\Empty|Any|(Pipe|Document|Inline)+)? & (Documentation|PipeInfo)*)
    }
 
 [
@@ -235,9 +240,8 @@ Document =
 ]
 Inline =
    element inline {
-      exclude-inline-prefixes.attr?,
-      attribute expand-text { xsd:boolean }?,
       common.attributes,
+      inline.attributes,
       use-when.attr?,
       Any
    }
@@ -333,8 +337,9 @@ WithOptionSelect =
       as.attr?,
       select.attr,
       common.attributes,
+      inline.attributes,
       use-when.attr?,
-      ((\Empty|Pipe|Document|Inline)? & (Namespaces|Documentation|PipeInfo)*)
+      ((\Empty|Pipe|Document|Any|Inline)? & (Namespaces|Documentation|PipeInfo)*)
    }
 
 [
@@ -353,8 +358,9 @@ VariableSelect =
       as.attr?,
       select.attr,
       common.attributes,
+      inline.attributes,
       use-when.attr?,
-      ((\Empty|Pipe|Document|Inline)? & (Namespaces|Documentation|PipeInfo)*)
+      ((\Empty|Pipe|Document|Any|Inline)? & (Namespaces|Documentation|PipeInfo)*)
    }
 
 [
@@ -413,8 +419,9 @@ IterationSource =
    element iteration-source {
       select.attr?,
       common.attributes,
+      inline.attributes,
       use-when.attr?,
-      ((\Empty|(Pipe|Document|Inline)+)? & (Documentation|PipeInfo)*)
+      ((\Empty|Any|(Pipe|Document|Inline)+)? & (Documentation|PipeInfo)*)
    }
 
 # ============================================================
@@ -437,8 +444,9 @@ Viewport =
 ViewportSource =
    element viewport-source {
       common.attributes,
+      inline.attributes,
       use-when.attr?,
-      ((Pipe|Document|Inline)? & (Documentation|PipeInfo)*)
+      ((Pipe|Document|Any|Inline)? & (Documentation|PipeInfo)*)
    }
 
 # ============================================================
@@ -465,8 +473,9 @@ Choose =
 XPathContext =
    element xpath-context {
       common.attributes,
+      inline.attributes,
       use-when.attr?,
-      ((\Empty|Pipe|Document|Inline) & (Documentation|PipeInfo)*)
+      ((\Empty|Pipe|Document|Any|Inline) & (Documentation|PipeInfo)*)
    }
 
 [

--- a/langspec/xproc20/xproc20.xml
+++ b/langspec/xproc20/xproc20.xml
@@ -3196,7 +3196,7 @@ nodes (or an empty sequence).</error></para>
           port which has a default connection, then the input is treated as if the default
           connection appeared.</para>
 
-<para>An input declaration may contain foreign element(s), scoped outside of XProc vocabulary 
+<para>An input declaration may contain foreign element, scoped outside of XProc vocabulary 
 (<uri type="xmlnamespace">http://www.w3.org/ns/xproc</uri>) namespace. Each element is treated
 as if wrapped with a <tag>p:inline</tag> element. For definition of this implicit behaviour 
 see <tag>p:inline</tag>.</para>

--- a/langspec/xproc20/xproc20.xml
+++ b/langspec/xproc20/xproc20.xml
@@ -2789,6 +2789,10 @@ item is undefined.</para>
 <para>If the context node is connected to <tag>p:empty</tag>, or is
 unconnected and the <glossterm>default readable port</glossterm> is
 undefined, the context item is undefined.</para>
+
+<para>For <tag class="attribute">exclude-inline-prefixes</tag> and <tag class="attribute">expand-text</tag>, see <tag>p:inline</tag> .  
+</para>
+            
 </section>
 
 <section xml:id="p.when"><title>p:when</title><para>A
@@ -3104,6 +3108,9 @@ and <tag class="attribute">primary</tag> is not specified. <error
 code="S0030">It is a <glossterm>static error</glossterm> to specify
 that more than one input port is the primary.</error></para>
 
+<para>For <tag class="attribute">exclude-inline-prefixes</tag> and <tag class="attribute">expand-text</tag>, see <tag>p:inline</tag> .  
+</para>
+        
 <para>The <tag class="attribute">content-types</tag> attribute lists one
 or more (space separated) content types that this input port will
 accept. A content type must be of the form
@@ -3188,6 +3195,12 @@ nodes (or an empty sequence).</error></para>
           declaration may include a default connection. If no connection is provided for an input
           port which has a default connection, then the input is treated as if the default
           connection appeared.</para>
+
+<para>An input declaration may contain foreign element(s), scoped outside of XProc vocabulary 
+(<uri type="xmlnamespace">http://www.w3.org/ns/xproc</uri>) namespace. Each element is treated
+as if wrapped with a <tag>p:inline</tag> element. For definition of this implicit behaviour 
+see <tag>p:inline</tag>.</para>
+
 <para>A default connection does not satisfy the requirement
           that a primary input port is automatically connected by the processor, nor is it used when
           no default readable port is defined. In other words, a <tag>p:declare-step</tag> or a
@@ -3204,7 +3217,10 @@ nodes (or an empty sequence).</error></para>
       <e:rng-pattern name="IterationSource"/>
       <para>The <tag class="attribute">select</tag> attribute and <glossterm>connection</glossterm>
         of a <tag>p:iteration-source</tag> work the same way that they do in a
-        <tag>p:input</tag>.</para></section>
+        <tag>p:input</tag>.</para>
+        <para>For <tag class="attribute">exclude-inline-prefixes</tag> and <tag class="attribute">expand-text</tag>, see <tag>p:inline</tag> .  
+        </para>
+    </section>
     <section xml:id="p.viewport-source"><title>p:viewport-source</title><para>A
           <tag>p:viewport-source</tag> identifies input to a <tag>p:viewport</tag>.</para>
       <e:rng-pattern name="ViewportSource"/>
@@ -3212,7 +3228,10 @@ nodes (or an empty sequence).</error></para>
         connections work on a <tag>p:input</tag>. <error code="D0003">It is a <glossterm>dynamic
             error</glossterm> unless exactly one document appears on the
             <tag>p:viewport-source</tag>.</error> No <tag class="attribute">select</tag> expression
-        is allowed.</para></section>
+        is allowed.</para>
+        <para>For <tag class="attribute">exclude-inline-prefixes</tag> and <tag class="attribute">expand-text</tag>, see <tag>p:inline</tag> .  
+        </para>
+</section>
     <!-- ============================================================ -->
     <section xml:id="p.output"><title>p:output</title><para>A <tag>p:output</tag> identifies an
         output port, optionally connecting an input for it, if necessary.</para>
@@ -3246,7 +3265,10 @@ nodes (or an empty sequence).</error></para>
           <tag>p:document</tag> inside a <tag>p:output</tag> causes the processor to <emphasis>read
           that document</emphasis> and provide it on the output port. It <emphasis>does
           not</emphasis> cause the processor to <emphasis>write</emphasis> the output to that
-        document.</para></section>
+        document.</para>
+        <para>For <tag class="attribute">exclude-inline-prefixes</tag> and <tag class="attribute">expand-text</tag>, see <tag>p:inline</tag> .  
+        </para>
+</section>
     <!-- ============================================================ -->
     <section xml:id="p.log"><title>p:log</title><para>A <tag>p:log</tag> element is a debugging aid.
         It associates a URI with a specific output port on a step:</para>
@@ -3386,6 +3408,9 @@ implied as the document connection, the context item is undefined.
 the <tag class="attribute">select</tag> expression makes reference to
 the context node, size, or position when the context item is
 undefined.</error>
+</para>
+
+<para>For <tag class="attribute">exclude-inline-prefixes</tag> and <tag class="attribute">expand-text</tag>, see <tag>p:inline</tag> .  
 </para>
 </section>
 
@@ -3533,6 +3558,8 @@ the context node, size, or position when the context item is
 undefined.</error>
 </para>
 
+<para>For <tag class="attribute">exclude-inline-prefixes</tag> and <tag class="attribute">expand-text</tag>, see <tag>p:inline</tag> .  
+</para>
 </section>
 
 
@@ -3843,101 +3870,124 @@ See also <xref linkend="handling-imports"
         output port on one of the compound step's <glossterm>contained steps</glossterm>. In other
         words, the output of a compound step can simply be a copy of one of the available inputs or
         it can be the output of one of its children.</para></section>
-    <section xml:id="p.inline"><title>p:inline</title><para>A <tag>p:inline</tag> provides a
-        document inline.</para>
-      <e:rng-pattern name="Inline"/>
-      <para>The content of the <tag>p:inline</tag> element is wrapped in a document node and passed
-        as input. The base URI of the document is the base URI of the <tag>p:inline</tag> element.
-          <error code="S0024">It is a <glossterm>static error</glossterm> if the content of the
-            <tag>p:inline</tag> element does not consist of exactly one element, optionally preceded
-          and/or followed by any number of processing instructions, comments or whitespace
-          characters.</error></para>
-<para>The in-scope namespaces of the inline document differ from
-        the in-scope namespace of the content of the <tag>p:inline</tag> element in that bindings
-        for all its <emphasis>excluded namespaces</emphasis>, as defined below, are removed:</para><itemizedlist>
-        <listitem>
-          <para>The XProc namespace itself (<uri>http://www.w3.org/ns/xproc</uri>) is
-            excluded.</para>
-        </listitem>
-        <listitem>
-          <para>A namespace URI designated by using an <tag class="attribute"
-              >exclude-inline-prefixes</tag> attribute on the enclosing <tag>p:inline</tag> is
-            excluded.</para>
-        </listitem>
-        <listitem>
-          <para>A namespace URI designated by using an <tag class="attribute"
-              >exclude-inline-prefixes</tag> attribute on any ancestor <tag>p:declare-step</tag>,
-              <tag>p:pipeline</tag>, or <tag>p:library</tag> is also excluded. (In other words, the
-            effect of several <tag class="attribute">exclude-inline-prefixes</tag> attributes among
-            the ancestors of <tag>p:inline</tag> is cumulative.)</para>
-        </listitem>
-</itemizedlist>
-
-<para>The value of each prefix in the <tag
-class="attribute">exclude-inline-prefixes</tag> attribute is
-interpreted as follows:</para>
-
-<itemizedlist>
-<listitem>
-<para>The value of the attribute is either <literal>#all</literal>, or
-a whitespace-separated list of tokens, each of which is either a
-namespace prefix or <literal>#default</literal>. The namespace bound
-to each of the prefixes is designated as an excluded namespace. <error
-code="S0057">It is a <glossterm>static error</glossterm> if the <tag
-class="attribute" >exclude-inline-prefixes</tag> attribute does not
-contain a list of tokens or if any of those tokens (except
-<literal>#all</literal> or <literal>#default</literal>) is not a
-prefix bound to a namespace in the in-scope namespaces of the element
-on which it occurs.</error></para>
-</listitem>
-<listitem>
-<para>The default namespace of the element on which <tag
-class="attribute">exclude-inline-prefixes</tag> occurs may be
-designated as an excluded namespace by including
-<literal>#default</literal> in the list of namespace prefixes. <error
-code="S0058">It is a <glossterm>static error</glossterm> if the value
-<literal>#default</literal> is used within the <tag class="attribute"
->exclude-inline-prefixes</tag> attribute and there is no default
-namespace in scope.</error>
-</para>
-</listitem>
-<listitem>
-<para>The value <literal>#all</literal> indicates that all namespaces
-that are in scope for the element on which <tag
-class="attribute">exclude-inline-prefixes</tag> occurs are designated
-as excluded namespaces.</para>
-</listitem>
-</itemizedlist>
-
-<para>The XProc processor <rfc2119>must</rfc2119> include all in-scope
-prefixes that are not explicitly excluded. If the namespace associated with
-an excluded prefix is used in the expanded-QName of a descendant
-element or attribute,
-the processor <rfc2119>may</rfc2119> include that prefix anyway, or it may
-generate a new prefix.</para>
-
-<para>Consider this example:</para>
-
-<programlisting language="xml"><xi:include href="examples/exclude-pfx.txt" parse="text"/></programlisting>
-
-<para>which might produce a result like this:</para>
-
-<programlisting language="xml"><![CDATA[<doc xmlns:c="http://example.com/c">
+      <section xml:id="p.inline"><title>p:inline</title><para>A <tag>p:inline</tag> provides a
+          document inline.</para>
+          <e:rng-pattern name="Inline"/>
+          <para>The content of the <tag>p:inline</tag> element is wrapped in a document node and passed
+              as input. The base URI of the document is the base URI of the <tag>p:inline</tag> element.
+              <error code="S0024">It is a <glossterm>static error</glossterm> if the content of the
+                  <tag>p:inline</tag> element does not consist of exactly one element, optionally preceded
+                  and/or followed by any number of processing instructions, comments or whitespace
+                  characters.</error></para>
+          <para>The in-scope namespaces of the inline document differ from
+              the in-scope namespace of the content of the <tag>p:inline</tag> element in that bindings
+              for all its <emphasis>excluded namespaces</emphasis>, as defined below, are removed:</para><itemizedlist>
+                  <listitem>
+                      <para>The XProc namespace itself (<uri>http://www.w3.org/ns/xproc</uri>) is
+                          excluded.</para>
+                  </listitem>
+                  <listitem>
+                      <para>A namespace URI designated by using an <tag class="attribute"
+                          >exclude-inline-prefixes</tag> attribute on the enclosing <tag>p:inline</tag> is
+                          excluded.</para>
+                  </listitem>
+                  <listitem>
+                      <para>A namespace URI designated by using an <tag class="attribute"
+                          >exclude-inline-prefixes</tag> attribute on any ancestor <tag>p:declare-step</tag>,
+                          <tag>p:pipeline</tag>, or <tag>p:library</tag> is also excluded. (In other words, the
+                          effect of several <tag class="attribute">exclude-inline-prefixes</tag> attributes among
+                          the ancestors of <tag>p:inline</tag> is cumulative.)</para>
+                  </listitem>
+              </itemizedlist>
+          
+          <para>The value of each prefix in the <tag
+              class="attribute">exclude-inline-prefixes</tag> attribute is
+              interpreted as follows:</para>
+          
+          <itemizedlist>
+              <listitem>
+                  <para>The value of the attribute is either <literal>#all</literal>, or
+                      a whitespace-separated list of tokens, each of which is either a
+                      namespace prefix or <literal>#default</literal>. The namespace bound
+                      to each of the prefixes is designated as an excluded namespace. <error
+                          code="S0057">It is a <glossterm>static error</glossterm> if the <tag
+                              class="attribute" >exclude-inline-prefixes</tag> attribute does not
+                          contain a list of tokens or if any of those tokens (except
+                          <literal>#all</literal> or <literal>#default</literal>) is not a
+                          prefix bound to a namespace in the in-scope namespaces of the element
+                          on which it occurs.</error></para>
+              </listitem>
+              <listitem>
+                  <para>The default namespace of the element on which <tag
+                      class="attribute">exclude-inline-prefixes</tag> occurs may be
+                      designated as an excluded namespace by including
+                      <literal>#default</literal> in the list of namespace prefixes. <error
+                          code="S0058">It is a <glossterm>static error</glossterm> if the value
+                          <literal>#default</literal> is used within the <tag class="attribute"
+                              >exclude-inline-prefixes</tag> attribute and there is no default
+                          namespace in scope.</error>
+                  </para>
+              </listitem>
+              <listitem>
+                  <para>The value <literal>#all</literal> indicates that all namespaces
+                      that are in scope for the element on which <tag
+                          class="attribute">exclude-inline-prefixes</tag> occurs are designated
+                      as excluded namespaces.</para>
+              </listitem>
+          </itemizedlist>
+          
+          <para>The XProc processor <rfc2119>must</rfc2119> include all in-scope
+              prefixes that are not explicitly excluded. If the namespace associated with
+              an excluded prefix is used in the expanded-QName of a descendant
+              element or attribute,
+              the processor <rfc2119>may</rfc2119> include that prefix anyway, or it may
+              generate a new prefix.</para>
+          
+          <para>Consider this example:</para>
+          
+          <programlisting language="xml"><xi:include href="examples/exclude-pfx.txt" parse="text"/></programlisting>
+          
+          <para>which might produce a result like this:</para>
+          
+          <programlisting language="xml"><![CDATA[<doc xmlns:c="http://example.com/c">
    <b:part xmlns:b="http://example.com/b"/>
  </doc>]]></programlisting>
+          
+          <para>The declaration for “<literal>c</literal>” must
+              be present because it was not excluded. The “<literal>part</literal>” element
+              uses the namespace bound to “<literal>b</literal>”, so <emphasis>some</emphasis>
+              binding must be present. In this example, the original
+              prefix has been preserved, but it would be equally correct if a different
+              prefix had been used.</para>
+          
+          <para>If the <tag class="attribute">expand-text</tag> attribute is
+              true, then each text node within the <tag>p:inline</tag> is evaluated as
+              a <glossterm>text value template</glossterm>. The context node for
+              these expressions is undefined.</para>
 
-<para>The declaration for “<literal>c</literal>” must
-be present because it was not excluded. The “<literal>part</literal>” element
-uses the namespace bound to “<literal>b</literal>”, so <emphasis>some</emphasis>
-binding must be present. In this example, the original
-prefix has been preserved, but it would be equally correct if a different
-prefix had been used.</para>
-
-<para>If the <tag class="attribute">expand-text</tag> attribute is
-true, then each text node within the <tag>p:inline</tag> is evaluated as
-a <glossterm>text value template</glossterm>. The context node for
-these expressions is undefined.</para>
-</section>
+          <para>Optionally, a single element scoped outside of XProc vocabulary (<uri type="xmlnamespace">http://www.w3.org/ns/xproc</uri>) 
+              namespace may be provided wherever a <tag>p:inline</tag> element can exist.
+              The foreign element will be interpreted as if wrapped with an implicit <tag>p:inline</tag>.</para>
+          
+          <para>The following example demonstrates this implied behaviour.</para>
+          <programlisting language="xml"><![CDATA[<p:identity name="identity" code="my:implicitinline1">
+    <p:input port="source">
+        <c:data content-type="image/png">BASE64ENCODEDDATA</c:data>
+    </p:input>
+</p:identity>]]></programlisting>
+          
+          <para>Would be interpreted as the following code listing.</para>
+          <programlisting language="xml"><![CDATA[<p:identity name="identity" code="my:implicitinline2">
+    <p:input port="source">
+        <p:inline>
+            <c:data content-type="image/png">BASE64ENCODEDDATA</c:data>
+        </p:inline>
+    </p:input>
+</p:identity>]]></programlisting>
+          
+          <para>Explicit <tag>p:inline</tag>(s) would be required if the author wants to include top level comments, processing instruction nodes,
+              or elements from XProc vocabulary (<uri type="xmlnamespace">http://www.w3.org/ns/xproc</uri>) namespace.</para>          
+      </section>
 <section xml:id="p.document">
 <title>p:document</title>
 


### PR DESCRIPTION
apply changes to new doc structure ... as per last WG meeting allow exclude-inline-prefixes and expand-text to all elements that can contain p:inline. Allow only a single foreign element. Amend schema.

Diff version of (my) spec
http://xquery.github.io/xproc-vnext-spec/langspec/xproc20/head/xproc20/diff.html
